### PR TITLE
Addition of event catcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@ window.addEventListener('DOMContentLoaded', (event)=>{
 
 //saves what is in the notepad
 hotkeys('ctrl+s', function() {
+                event.preventDefault();
                 fs.writeFile('/note', document.querySelector('#note').innerHTML, err => {
                 if (err) throw err;
                 else alert('Note saved');


### PR DESCRIPTION
Closes: #1

The addition of a event catcher for the key bind ctrl+s will prevent browser key binds from interfering with the workflow.